### PR TITLE
Log errors for tileset parsing

### DIFF
--- a/tiled/tiled.odin
+++ b/tiled/tiled.odin
@@ -41,10 +41,15 @@ parse_tileset :: proc(path: string) -> Tileset {
 	ts: Tileset
 	jdata, ok := os.read_entire_file(path)
 	if !ok {
+		fmt.print("Failed to read file: ", path, "\n")
 		return ts
 	}
 
 	err := json.unmarshal(jdata, &ts)
+	if err != nil {
+		fmt.print("Failed to unmarshal JSON: ", err, "\n")
+		return ts
+	}
 	return ts
 }
 


### PR DESCRIPTION
would also be nice at a later point for the functions to use multiple returns instead of just logging the errors

https://odin-lang.org/docs/overview/#or_return-operator