### PR TITLE
Use tagged union for data field

### DIFF
--- a/tiled/tiled.odin
+++ b/tiled/tiled.odin
@@ -48,6 +48,12 @@ parse_tileset :: proc(path: string) -> Tileset {
 	return ts
 }
 
+// Array of unsigned int (GIDs) or base64-encoded data
+ArrayOrString :: union {
+	[]i32,
+	string,
+}
+
 // Map describes a Tiled map.
 Map :: struct {
 	background_color:  string `json:"backgroundcolor"`,               // Hex-formatted color (#RRGGBB or #AARRGGBB) (optional).
@@ -95,7 +101,7 @@ Layer :: struct {
 	// TileLayer only
 	chunks:            []Chunk `json: "chunks"`,              // Array of chunks (optional, for ininite maps)
 	compression:       string `json: "compression"`,               // "zlib", "gzip" or empty (default)
-	data:              []i32 `json: "data"`,                  // Array or string. Array of unsigned int (GIDs) or base64-encoded data
+	data:              ArrayOrString `json: "data"`,
 	encoding:          string `json: "encoding"`,               // "csv" (default) or "base64"
 
 	// ObjectGroup only
@@ -112,7 +118,7 @@ Layer :: struct {
 
 // Chunk is used to store the tile layer data for infinite maps.
 Chunk :: struct {
-	data:              any `json: "data"`,                  // Array of unsigned int (GIDs) or base64-encoded data
+	data:              ArrayOrString `json: "data"`,
 	height:            i32 `json: "height"`,                  // Height in tiles
 	width:             i32 `json: "width"`,                  // Width in tiles
 	x:                 i32 `json: "x"`,                  // X coordinate in tiles


### PR DESCRIPTION
Closes #1 

Mirrors the described type in the docs
![image](https://github.com/user-attachments/assets/6292c92a-ac62-4997-ac58-d8635d373a3b)

todo: would have to do a type switch in the example now if data is base64